### PR TITLE
Add support for email HTML with text version:

### DIFF
--- a/Sources/SMTP.swift
+++ b/Sources/SMTP.swift
@@ -395,12 +395,14 @@ public struct EMail {
     body += "MIME-Version: 1.0\r\nContent-type: multipart/mixed; boundary=\"\(boundary)\"\r\n\r\n"
 
     // add the html / plain text content body
-    if content.isEmpty {
+    if content.isEmpty && text.isEmpty {
       throw SMTPError.INVALID_CONTENT
     }else {
-      body += "--\(boundary)\r\nContent-Type: text/html;charset=utf8\r\n\r\n\(content)\r\n\r\n"
       if !text.isEmpty {
         body += "--\(boundary)\r\nContent-Type: text/plain; charset=utf8; format=flowed\r\n\r\n\(content)\r\n\r\n"
+      }
+      if !content.isEmpty {
+        body += "--\(boundary)\r\nContent-Type: text/html;charset=utf8\r\n\r\n\(content)\r\n\r\n"
       }
     }//end if
 

--- a/Sources/SMTP.swift
+++ b/Sources/SMTP.swift
@@ -392,17 +392,17 @@ public struct EMail {
     }//end if
 
     // mark the content type
-    body += "MIME-Version: 1.0\r\nContent-type: multipart/mixed; boundary=\"\(boundary)\"\r\n\r\n"
+    body += "MIME-Version: 1.0\r\nContent-type: multipart/alternative; boundary=\"\(boundary)\"\r\n\r\n"
 
     // add the html / plain text content body
     if content.isEmpty && text.isEmpty {
       throw SMTPError.INVALID_CONTENT
     }else {
       if !text.isEmpty {
-        body += "--\(boundary)\r\nContent-Type: text/plain; charset=utf8; format=flowed\r\n\r\n\(content)\r\n\r\n"
+        body += "--\(boundary)\r\nContent-Type: text/plain; charset=UTF-8; format=flowed\r\n\r\n\(text)\r\n\r\n"
       }
       if !content.isEmpty {
-        body += "--\(boundary)\r\nContent-Type: text/html;charset=utf8\r\n\r\n\(content)\r\n\r\n"
+        body += "--\(boundary)\r\nContent-Type: text/html;charset=UTF-8\r\n\r\n\(content)\r\n\r\n"
       }
     }//end if
 

--- a/Sources/SMTP.swift
+++ b/Sources/SMTP.swift
@@ -223,6 +223,9 @@ public struct EMail {
 
   /// email content body
   public var content: String = ""
+  
+  // text version, to be added with a html version.
+  public var text: String = ""
 
   /// an alternative name of content
   public var html: String {
@@ -396,6 +399,9 @@ public struct EMail {
       throw SMTPError.INVALID_CONTENT
     }else {
       body += "--\(boundary)\r\nContent-Type: text/html;charset=utf8\r\n\r\n\(content)\r\n\r\n"
+      if !text.isEmpty {
+        body += "--\(boundary)\r\nContent-Type: text/plain; charset=utf8; format=flowed\r\n\r\n\(content)\r\n\r\n"
+      }
     }//end if
 
     // add the attachements


### PR DESCRIPTION
- Use content attribute for HTML version
- Use the new "text" attribute for TEXT version.