### PR TITLE
Bugfix html custom setter

### DIFF
--- a/Sources/SMTP.swift
+++ b/Sources/SMTP.swift
@@ -230,7 +230,7 @@ public struct EMail {
   /// an alternative name of content
   public var html: String {
     get { return content }
-    set { content = html }
+    set { content = newValue }
   }//end html
 
   /// constructor


### PR DESCRIPTION
You can't use the var html in setter. This causes the custom getter to be used when updating the variable "content" so you are basically saying: content = content. 
One must use "newValue" to actually assign the new value :)