### PR TITLE
Fixing missing mime encoded word on subject and recipients

### DIFF
--- a/Sources/PerfectSMTP/PerfectSMTP.swift
+++ b/Sources/PerfectSMTP/PerfectSMTP.swift
@@ -306,7 +306,7 @@ public class EMail {
 		if subject.isEmpty {
 			throw SMTPError.INVALID_SUBJECT
 		} else {
-			body += "Subject: \(subject)\r\n"
+			body += "Subject: =?UTF-8?Q?\(subject)?=\r\n"
 		}
 		// mark the content type
 		body += "MIME-Version: 1.0\r\nContent-type: multipart/alternative; boundary=\"\(boundary)\"\r\n\r\n"

--- a/Sources/PerfectSMTP/PerfectSMTP.swift
+++ b/Sources/PerfectSMTP/PerfectSMTP.swift
@@ -83,6 +83,13 @@ public struct Recipient {
 
 /// string extension for express conversion from recipient, etc.
 extension String {
+    func base64Encoded() -> String? {
+        if let data = self.data(using: .utf8) {
+            return data.base64EncodedString()
+        }
+        return nil
+    }
+    
 	/// get RFC 5322-compliant date for email
 	static var rfc5322Date: String {
 		let dateFormatter = DateFormatter()
@@ -100,7 +107,11 @@ extension String {
 		if recipient.name.isEmpty {
 			self = recipient.address
 		} else {
-			self = "\"\(recipient.name)\" <\(recipient.address)>"
+            if let recipientNameB64 = recipient.name.base64Encoded() {
+                self = "=?utf-8?B?\(recipientNameB64)?= <\(recipient.address)>"
+            } else {
+                self = "\"\(recipient.name)\" <\(recipient.address)>"
+            }
 		}
 	}
 	


### PR DESCRIPTION
According to the MIME standard (https://en.wikipedia.org/wiki/MIME#Encoded-Word) we have to specify the content encoding for subject and recipients otherwise the mail client take his default encoding (for example Microsoft Outlook Online is in Latin1 by default - see bellow).

For recipient I have used the base64 encryption because the Q-encoding (used in subject) doesn't give the right results for the "From" field in my tests.

Example on Microsoft Outllook online : 
Before the fix (look at the subject) : 
<img width="351" alt="before" src="https://user-images.githubusercontent.com/2733648/43795366-6dd40e9a-9a81-11e8-90ea-8b6a16e22527.png">

After the fix (look at the subject) : 
<img width="347" alt="after" src="https://user-images.githubusercontent.com/2733648/43795381-7bf3a8b4-9a81-11e8-873a-04b36131a5b0.png">
